### PR TITLE
Add Support for Glossaries

### DIFF
--- a/apps/workflow-server/src/main/java/com.coremedia.labs.translation.deepl.workflow/DeeplTranslationService.java
+++ b/apps/workflow-server/src/main/java/com.coremedia.labs.translation.deepl.workflow/DeeplTranslationService.java
@@ -8,6 +8,7 @@ import com.coremedia.translate.xliff.core.jaxb.*;
 import com.deepl.api.DeepLClient;
 import com.deepl.api.DeepLException;
 import com.deepl.api.TextResult;
+import com.deepl.api.TextTranslationOptions;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import org.apache.commons.lang3.StringUtils;
@@ -27,7 +28,7 @@ public class DeeplTranslationService {
   public static final String SOURCE_PREFIX = "<source xmlns=\"urn:oasis:names:tc:xliff:document:1.2\">";
   public static final String SOURCE_SUFFIX = "</source>";
 
-  private final DeeplConfiguration config;
+  private DeeplConfiguration config;
   private final ContentRepository contentRepository;
   private DeepLClient deepLClient;
 
@@ -37,6 +38,7 @@ public class DeeplTranslationService {
   }
 
   public void initialize(DeeplConfiguration config) {
+    this.config = config;
     this.deepLClient = new DeepLClient(config.getApiKey(), config.getClientOptions());
   }
 
@@ -50,6 +52,14 @@ public class DeeplTranslationService {
    */
   public Optional<String> translate(String toTranslate, String sourceLanguage, String targetLanguage) throws DeepLException, InterruptedException {
     LOG.debug("Translating from {} to {}: {}", sourceLanguage, targetLanguage, toTranslate);
+    TextTranslationOptions textTranslationOptions = config.getTextTranslationOptions();
+    if (config.getGlossaries() != null && !config.getGlossaries().isEmpty()) {
+      String targetGlossary = config.getGlossaries().stream().filter(m -> targetLanguage.contains(m.get("locale")))
+              .findFirst()
+              .map(m -> m.get("glossaryId"))
+              .orElse(StringUtils.EMPTY);
+      textTranslationOptions.setGlossary(targetGlossary);
+    }
     TextResult textResult = deepLClient.translateText(toTranslate, sourceLanguage, targetLanguage, config.getTextTranslationOptions());
     return Optional.ofNullable(textResult.getText());
   }

--- a/shared/middle/deepl-config/src/main/java/com/coremedia/labs/translation/deepl/workflow/config/DeeplConfiguration.java
+++ b/shared/middle/deepl-config/src/main/java/com/coremedia/labs/translation/deepl/workflow/config/DeeplConfiguration.java
@@ -58,6 +58,8 @@ public class DeeplConfiguration {
    */
   protected Map<String, String> fallbackLocalesForLanguages;
 
+  protected List<Map<String, String>> glossaries;
+
   public DeeplConfiguration() {
     this.clientOptions = new DeepLClientOptions();
     this.textTranslationOptions = new TextTranslationOptions();
@@ -128,6 +130,14 @@ public class DeeplConfiguration {
 
   public void setFallbackLocalesForLanguages(Map<String, String> fallbackLocalesForLanguages) {
     this.fallbackLocalesForLanguages = fallbackLocalesForLanguages;
+  }
+
+  public List<Map<String, String>> getGlossaries() {
+    return glossaries;
+  }
+
+  public void setGlossaries(List<Map<String, String>> glossaries) {
+    this.glossaries = glossaries;
   }
 
   public static DeeplConfiguration from(DeeplConfiguration source) {
@@ -212,6 +222,9 @@ public class DeeplConfiguration {
     } else {
       merged.getTextTranslationOptions().setOutlineDetection(defaultConfig.getTextTranslationOptions().isOutlineDetection());
       merged.getTextTranslationOptions().setPreserveFormatting(defaultConfig.getTextTranslationOptions().isPreserveFormatting());
+    }
+    if (otherMap.containsKey("glossaries")) {
+      merged.setGlossaries((List<Map<String, String>>) otherMap.get("glossaries"));
     }
     return merged;
   }


### PR DESCRIPTION
Add Support for Glossaries that are create in the DeepL Backoffice. 

The Glossaries for each language can be set up in the DeepL Settings. 

<img width="1847" height="412" alt="image" src="https://github.com/user-attachments/assets/90e52091-a9b6-4e7a-bdfb-256dd1ddaa33" />
