### PR TITLE
Add richtext handling to translation method in DeeplTranslationService

### DIFF
--- a/apps/workflow-server/src/main/java/com.coremedia.labs.translation.deepl.workflow/DeeplTranslationService.java
+++ b/apps/workflow-server/src/main/java/com.coremedia.labs.translation.deepl.workflow/DeeplTranslationService.java
@@ -50,7 +50,7 @@ public class DeeplTranslationService {
    * @param targetLanguage the language to translate to
    * @return a string if the translation succeed
    */
-  public Optional<String> translate(String toTranslate, String sourceLanguage, String targetLanguage) throws DeepLException, InterruptedException {
+  public Optional<String> translate(String toTranslate, String sourceLanguage, String targetLanguage, boolean isRichtext) throws DeepLException, InterruptedException {
     LOG.debug("Translating from {} to {}: {}", sourceLanguage, targetLanguage, toTranslate);
     TextTranslationOptions textTranslationOptions = config.getTextTranslationOptions();
     if (config.getGlossaries() != null && !config.getGlossaries().isEmpty()) {
@@ -59,6 +59,9 @@ public class DeeplTranslationService {
               .map(m -> m.get("glossaryId"))
               .orElse(StringUtils.EMPTY);
       textTranslationOptions.setGlossary(targetGlossary);
+    }
+    if (isRichtext) {
+        textTranslationOptions.setTagHandling("xml");
     }
     TextResult textResult = deepLClient.translateText(toTranslate, sourceLanguage, targetLanguage, config.getTextTranslationOptions());
     return Optional.ofNullable(textResult.getText());
@@ -170,7 +173,7 @@ public class DeeplTranslationService {
 
     String key = result.replace("\n", "").replaceAll("\\s+", " ").trim();
     if (StringUtils.isNotBlank(key)) {
-      return translate(key, sourceLanguage, targetLanguage);
+      return translate(key, sourceLanguage, targetLanguage, true);
     }
 
     return Optional.empty();


### PR DESCRIPTION
This pull request updates the DeepL translation workflow to better support rich text translation. The main change is the introduction of an `isRichtext` parameter to the `translate` method, allowing the service to handle XML tag processing when translating rich text content.

Enhancements for rich text translation:

* Added an `isRichtext` boolean parameter to the `translate` method in `DeeplTranslationService.java`, enabling the caller to specify when the input contains rich text.
* When `isRichtext` is true, the translation options now set `tagHandling` to `"xml"`, ensuring proper handling of XML tags during translation.
* Updated the internal call to `translate` within `itemAsString` to pass `true` for the `isRichtext` parameter, ensuring rich text items are processed correctly.