### PR TITLE
Bugfix/handle richtext

### DIFF
--- a/apps/workflow-server/src/main/java/com.coremedia.labs.translation.deepl.workflow/DeeplTranslationService.java
+++ b/apps/workflow-server/src/main/java/com.coremedia.labs.translation.deepl.workflow/DeeplTranslationService.java
@@ -50,7 +50,7 @@ public class DeeplTranslationService {
    * @param targetLanguage the language to translate to
    * @return a string if the translation succeed
    */
-  public Optional<String> translate(String toTranslate, String sourceLanguage, String targetLanguage) throws DeepLException, InterruptedException {
+  public Optional<String> translate(String toTranslate, String sourceLanguage, String targetLanguage, boolean isRichtext) throws DeepLException, InterruptedException {
     LOG.debug("Translating from {} to {}: {}", sourceLanguage, targetLanguage, toTranslate);
     TextTranslationOptions textTranslationOptions = config.getTextTranslationOptions();
     if (config.getGlossaries() != null && !config.getGlossaries().isEmpty()) {
@@ -59,6 +59,9 @@ public class DeeplTranslationService {
               .map(m -> m.get("glossaryId"))
               .orElse(StringUtils.EMPTY);
       textTranslationOptions.setGlossary(targetGlossary);
+    }
+    if (isRichtext) {
+        textTranslationOptions.setTagHandling("xml");
     }
     TextResult textResult = deepLClient.translateText(toTranslate, sourceLanguage, targetLanguage, config.getTextTranslationOptions());
     return Optional.ofNullable(textResult.getText());
@@ -170,7 +173,7 @@ public class DeeplTranslationService {
 
     String key = result.replace("\n", "").replaceAll("\\s+", " ").trim();
     if (StringUtils.isNotBlank(key)) {
-      return translate(key, sourceLanguage, targetLanguage);
+      return translate(key, sourceLanguage, targetLanguage, true);
     }
 
     return Optional.empty();


### PR DESCRIPTION
This pull request updates the `DeeplTranslationService` to support rich text translation by allowing the DeepL API to handle XML tags when translating content. The main changes involve extending the translation method to accept a flag for rich text and updating its usage to enable proper tag handling.

Enhancements for rich text translation:

* The `translate` method in `DeeplTranslationService.java` now accepts an additional `isRichtext` boolean parameter to indicate whether the input text should be treated as rich text.
* When `isRichtext` is true, the translation options are set to handle XML tags, allowing DeepL to process rich text content correctly.
* The internal usage of the `translate` method in `itemAsString` has been updated to pass `true` for the `isRichtext` parameter, ensuring rich text is handled appropriately during translation.