### PR TITLE
Add styleRules support to DeeplConfiguration and update version to 1.…

### DIFF
--- a/apps/studio-server/pom.xml
+++ b/apps/studio-server/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <coremedia.project.extension.for>studio-server</coremedia.project.extension.for>
-    <deepl.version>1.10.0</deepl.version>
+    <deepl.version>1.14.0</deepl.version>
   </properties>
 
   <dependencies>

--- a/apps/workflow-server/pom.xml
+++ b/apps/workflow-server/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <coremedia.project.extension.for>workflow-server</coremedia.project.extension.for>
-    <deepl.version>1.10.0</deepl.version>
+    <deepl.version>1.14.0</deepl.version>
     <cm.middle.core.version>2506.0.2</cm.middle.core.version>
   </properties>
 

--- a/apps/workflow-server/src/main/java/com.coremedia.labs.translation.deepl.workflow/DeeplTranslationService.java
+++ b/apps/workflow-server/src/main/java/com.coremedia.labs.translation.deepl.workflow/DeeplTranslationService.java
@@ -60,6 +60,13 @@ public class DeeplTranslationService {
               .orElse(StringUtils.EMPTY);
       textTranslationOptions.setGlossary(targetGlossary);
     }
+    if (config.getStyleRules() != null && !config.getStyleRules().isEmpty()) {
+      String targetStyleRules = config.getStyleRules().stream().filter(m -> targetLanguage.contains(m.get("locale")))
+              .findFirst()
+              .map(m -> m.get("styleRulesId"))
+              .orElse(StringUtils.EMPTY);
+      textTranslationOptions.setStyleId(targetStyleRules);
+    }
     if (isRichtext) {
         textTranslationOptions.setTagHandling("xml");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <docs.directory>${project.basedir}/docs</docs.directory>
-    <deepl.version>1.10.0</deepl.version>
+    <deepl.version>1.14.0</deepl.version>
     <cm.middle.core.version>2506.0.2</cm.middle.core.version>
   </properties>
 

--- a/shared/middle/deepl-config/pom.xml
+++ b/shared/middle/deepl-config/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>deepl-config</artifactId>
 
   <properties>
-    <deepl.version>1.10.0</deepl.version>
+    <deepl.version>1.14.0</deepl.version>
     <modelmapper.version>3.2.3</modelmapper.version>
   </properties>
   <dependencies>

--- a/shared/middle/deepl-config/src/main/java/com/coremedia/labs/translation/deepl/workflow/config/DeeplConfiguration.java
+++ b/shared/middle/deepl-config/src/main/java/com/coremedia/labs/translation/deepl/workflow/config/DeeplConfiguration.java
@@ -60,6 +60,8 @@ public class DeeplConfiguration {
 
   protected List<Map<String, String>> glossaries;
 
+  protected List<Map<String, String>> styleRules;
+
   public DeeplConfiguration() {
     this.clientOptions = new DeepLClientOptions();
     this.textTranslationOptions = new TextTranslationOptions();
@@ -138,6 +140,14 @@ public class DeeplConfiguration {
 
   public void setGlossaries(List<Map<String, String>> glossaries) {
     this.glossaries = glossaries;
+  }
+
+  public List<Map<String, String>> getStyleRules() {
+    return styleRules;
+  }
+
+  public void setStyleRules(List<Map<String, String>> styleRules) {
+    this.styleRules = styleRules;
   }
 
   public static DeeplConfiguration from(DeeplConfiguration source) {
@@ -225,6 +235,9 @@ public class DeeplConfiguration {
     }
     if (otherMap.containsKey("glossaries")) {
       merged.setGlossaries((List<Map<String, String>>) otherMap.get("glossaries"));
+    }
+    if (otherMap.containsKey("styleRules")) {
+      merged.setStyleRules((List<Map<String, String>>) otherMap.get("styleRules"));
     }
     return merged;
   }


### PR DESCRIPTION
This pull request updates the DeepL integration across several modules to support the use of style rules in translations, in addition to upgrading the DeepL client library. The main changes involve updating configuration models and translation logic to handle style rules, as well as bumping the DeepL dependency version.

Dependency upgrades:

* Upgraded the DeepL client library version from `1.10.0` to `1.14.0` in the root `pom.xml`, `apps/studio-server/pom.xml`, `apps/workflow-server/pom.xml`, and `shared/middle/deepl-config/pom.xml` to ensure compatibility with new features. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L27-R27) [[2]](diffhunk://#diff-0dba7b09185f2b718919cb7d09662638b409a44c0f86453bfbb01082f37cbb44L17-R17) [[3]](diffhunk://#diff-acc4cc8eb3a0e5c586c2eea2e1e1696681fcec7a5459d71c4532d8c36bebc0e0L17-R17) [[4]](diffhunk://#diff-4becc8463fe4329be536265790d56272fa41cac9e84fd14ba16864dd407d9e58L16-R16)

Support for style rules in configuration:

* Added a `styleRules` property (with getter and setter) to the `DeeplConfiguration` class to allow configuration of translation style rules. Also updated the static `merge` method to handle merging of `styleRules`. [[1]](diffhunk://#diff-505dbcd3389910c7bbf289c1a69f3374c041bb3b047d040da2b5296a5ec1cb72R63-R64) [[2]](diffhunk://#diff-505dbcd3389910c7bbf289c1a69f3374c041bb3b047d040da2b5296a5ec1cb72R145-R152) [[3]](diffhunk://#diff-505dbcd3389910c7bbf289c1a69f3374c041bb3b047d040da2b5296a5ec1cb72R239-R241)

Translation logic enhancements:

* Updated `DeeplTranslationService.translate` to apply style rules from the configuration when present, selecting the appropriate style rule based on the target language and setting it in the translation options.…14.0